### PR TITLE
Do not overwrite source maps on subsequent writeBundle calls

### DIFF
--- a/src/source-map-uploader-plugin.ts
+++ b/src/source-map-uploader-plugin.ts
@@ -81,7 +81,7 @@ export default function BugsnagSourceMapUploaderPlugin (config: SourceMapUploade
       newSourcemaps.forEach(({ map }) => uploadedMaps.add(map))
 
       await Promise.all(
-        sourcemaps.map(sourcemap => limitParallelism(() => uploadSourcemap(sourcemap))),
+        newSourcemaps.map(sourcemap => limitParallelism(() => uploadSourcemap(sourcemap))),
       )
     },
   }


### PR DESCRIPTION
This change keeps track of uploaded source maps and prevents re-uploading of maps on subsequent `writeBundle` calls.

## Goal

When using this plugin alongside the official `@vitejs/plugin-legacy`, uploading source maps fails if the `overwrite: false` option is provided.  With `@vitejs/plugin-legacy`, two bundles are created: one for legacy browser; one for modern browsers.  BugsnagSourceMapUploaderPlugin's `writeBundle` is thus called twice.  On the first call, the -legacy maps (e.g. index-legacy.hash.js.map) are uploaded.  On the second call, the plugin attempts to upload the modern maps (e.g. index.hash.js.map) _and the legacy maps_.  Since the legacy maps have already been uploaded, BS returns a 409, Duplicate when the `overwrite: false` option is provided.

## Design

## Changeset

A Set<string> of source maps is maintained at the BugsnagSourceMapUploaderPlugin level.  It's used to keep a unique set of uploaded source maps across multiple calls to `writeBundle`.  On subsequent calls, only new source maps are uploaded.

## Testing

Manual testing alongside `@vitejs/plugin-legacy` with `overwrite: false` set.  Prior to this change, this plugin failed due to a BS-side 409 http error.